### PR TITLE
Updated installation instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,36 @@ For the analog toolchain we need some tools, and a process design kit (PDK).
 - [xschem](https://github.com/StefanSchippers/xschem)
 - python > 3.10
 
-Clone the github repo 
+## Setup WSL (Applicable for Windows users)
+Install a Linux distribution such as Ubuntu 22.04 LTS by running the following command in PowerShell on Windows and follow the instructions.
+```bash
+wsl --install -d Ubuntu-22.04
+```
+
+When you have installed the Linux distribution and  signed into it, install make
+
+```bash
+sudo apt install make
+```
+
+## Setup public key towards github
+
+Do 
+
+```bash
+ssh-keygen -t rsa
+```
+
+And press "enter" on most things, or if you're paranoid, add a passphrase
+
+Then 
+```bash 
+cat ~/.ssh/id_rsa.pub 
+```
+
+And add the public key to your github account. Settings - SSH and GPG keys 
+
+## Clone the github repo, install, and set up tools
 
 ```bash
 git clone --recursive git@github.com:wulffern/aicex.git
@@ -54,7 +83,7 @@ cd ../..
 
 ``` bash
 cd aicex/ip/cicconf
-python3 -m pip install --user -e .
+python3 -m pip install .
 cd ../
 ```
 
@@ -69,7 +98,7 @@ cd ..
 
 ``` bash
 cd aicex/ip/cicsim
-python3 -m pip install --user -e .
+python3 -m pip install .
 cd ../..
 ```
 


### PR DESCRIPTION
Added a little about setting up WSL for Windows users.

Copied steps for how to set up a public key towards github from https://analogicus.com/aic2024/2023/11/16/Tools.html.

Due to a bug in setuptools with version number less than 62.0.0 being provided in Ubuntu 22.04 LTS, the steps where cicconf and cicsim is installed has been modified. Read what is written at the following links for more details:
https://github.com/pypa/pip/issues/7953
https://github.com/pypa/setuptools/issues/3019
https://bugs.launchpad.net/ubuntu/+source/setuptools/+bug/1994016